### PR TITLE
Shorten wget call

### DIFF
--- a/repository.eselect.in
+++ b/repository.eselect.in
@@ -48,7 +48,7 @@ update_cache() {
 		[[ $(find "${REMOTE_LIST_CACHE}" -newermt "@${refts}") ]] && return
 	fi
 
-	wget -N -P "${REMOTE_LIST_CACHEDIR}" "${REMOTE_LIST_URI}" ||
+	wget -O "${REMOTE_LIST_CACHE}" "${REMOTE_LIST_URI}" ||
 		die -q "unable to fetch repositories.xml"
 	# we need to touch it since:
 	# a. wget defaults to using server timestamp,


### PR DESCRIPTION
Later script dismisses the time, so I assume that -N, alias for
--timestamping, is here for its secondary purpose, overwriting the file
instead of creating a version with a suffix. File path is known, so -O
can be used instead of -P for directory.

What I'm really after is seeing how much of the system can be linked to
BusyBox, which has a wget applet without -N but with -O. In this rare
case, adding support has the benefit of saving a few characters.