### PR TITLE
Hide URLs for local overlays if remote exists with same name

### DIFF
--- a/eselect-repo-helper
+++ b/eselect-repo-helper
@@ -51,8 +51,8 @@ def do_list(args):
             'url': r.findtext('homepage'),
         }
 
-    for name in args.repos_conf:
-        if name != 'DEFAULT' and name not in repos:
+    for name, data in args.repos_conf.items():
+        if name != 'DEFAULT' and (name not in repos or 'sync-uri' not in data):
             repos[name] = {
                 'status': 'local',
                 'url': '',

--- a/test/test_list.py
+++ b/test/test_list.py
@@ -62,7 +62,7 @@ location = /tmp/foo
     assert (
         runner(repositories_xml, repos_conf.name, ['list']) ==
         (0, b'bar disabled https://example.com/bar\n'
-            b'foo need-update https://example.com/foo\n'
+            b'foo local \n'
             b'no-homepage disabled \n'
             b'weird-source disabled \n'))
 


### PR DESCRIPTION
When listing overlays, local overlays having sync-uri unset are displayed as remote if they have the same name as a remote overlay, which can be confusing. I ran into this with a local overlay called crossdev which also exists remotely.