### PR TITLE
repository.eselect.in: set profile EAPI (8)

### DIFF
--- a/repository.eselect.in
+++ b/repository.eselect.in
@@ -242,6 +242,8 @@ do_create() {
 	# create the repository boilerplate
 	mkdir -p "${path}"/{metadata,profiles} || die
 	echo "${name}" > "${path}"/profiles/repo_name || die
+	# PMS says PMs must default to EAPI 0 if unset
+	echo "8" > "${path}"/profiles/eapi || die
 	cat > "${path}"/metadata/layout.conf <<-EOF || die
 		masters = gentoo
 		thin-manifests = true


### PR DESCRIPTION
PMS says that PMs must assume EAPI 0 if it's not present, and not all PMs support this (pkgcraft doesn't, for example, and Portage is looking to drop it one day).

Just set EAPI 8. We do EAPI=5 in Gentoo right now for upgrade reasons but even that isn't really necessary.