### PR TITLE
Use full path in `eselect repository create <name> [<path>]`

### DIFF
--- a/repository.eselect.5.in
+++ b/repository.eselect.5.in
@@ -53,10 +53,6 @@ Name of the repository to create
 \fIpath\fP
 Directory to create the repository in. Must be an absolute path.
 If not specified, defaults to ${REPOS_BASE}/\fIname\fP
-.TP
-.B
-\fIsync-uri\fP
-Sync URI
 .SH ACTION: DISABLE
 Disable specified repositories without removing their contents
 .PP

--- a/repository.eselect.5.in
+++ b/repository.eselect.5.in
@@ -3,7 +3,7 @@
 .\" Copyright 2021-2025 Michał Górny
 .\" SPDX-License-Identifier: GPL-2.0-or-later
 .\"
-.TH repository.eselect 15 "2025-07-15" "Gentoo Linux" "eselect"
+.TH repository.eselect 5 "2025-07-15" "Gentoo Linux" "eselect"
 .SH NAME
 \fBrepository.eselect\fP - Manage repos.conf via eselect
 .SH SYNOPSIS

--- a/repository.eselect.5.in
+++ b/repository.eselect.5.in
@@ -51,8 +51,8 @@ Name of the repository to create
 .TP
 .B
 \fIpath\fP
-Directory to create the repository in. If not specified, defaults
-to a subdirectory of storage dir matching \fIname\fP
+Directory to create the repository in. Must be an absolute path.
+If not specified, defaults to ${REPOS_BASE}/\fIname\fP
 .TP
 .B
 \fIsync-uri\fP

--- a/repository.eselect.5.in
+++ b/repository.eselect.5.in
@@ -11,6 +11,7 @@
 .fam C
 \fBeselect\fP \fBrepository\fP [\fBhelp\fP|\fBusage\fP|\fBversion\fP]
 \fBeselect\fP \fBrepository\fP \fBadd\fP \fIname\fP \fIsync-type\fP \fIsync-uri\fP
+\fBeselect\fP \fBrepository\fP \fBcreate\fP \fIname\fP [\fIpath\fP]
 \fBeselect\fP \fBrepository\fP \fBdisable\fP [\fB-f\fP] (\fIname\fP|\fIindex\fP)
 \fBeselect\fP \fBrepository\fP \fBenable\fP (\fIname\fP|\fIindex\fP)
 \fBeselect\fP \fBrepository\fP \fBlist\fP [\fB-i\fP]

--- a/repository.eselect.in
+++ b/repository.eselect.in
@@ -223,6 +223,9 @@ describe_create_options() {
 
 do_create() {
 	[[ ${#} -eq 1 || ${#} -eq 2 ]] || die -q "incorrect parameters to create"
+	if [[ ${#} -eq 2 ]]; then
+		[[ ${2} != /* ]] && die -q "path must be absolute"
+	fi
 
 	get_config
 	update_cache

--- a/repository.eselect.in
+++ b/repository.eselect.in
@@ -218,7 +218,7 @@ describe_create_parameters() {
 
 describe_create_options() {
 	echo "<name>      : Name of the new repository"
-	echo "<path>      : Path to use (default: \${REPOS_BASE}/<name>)"
+	echo "<path>      : Absolute path to use (default: \${REPOS_BASE}/<name>)"
 }
 
 do_create() {


### PR DESCRIPTION
When provided a relative path such as `./my-repo`, it will store in `/etc/portage/repos.conf/eselect-repo.conf` the line `location = ./my-repo`, but it is more useful if it stores the full path instead.

It also removes trailing slash, for what it is worth.

Guys I made this change in the GitHub editor, I didn't even clone the repo in my machine to test my change. What I did was create a Bash script with portions of the eselect file and experiment on it locally until it worked (I was puzzled with `${path//\\/\\\\}` for a while).