### PR TITLE
Check repo name being created, as in PMS 3.1.5

### DIFF
--- a/repository.eselect.in
+++ b/repository.eselect.in
@@ -221,11 +221,36 @@ describe_create_options() {
 	echo "<path>      : Absolute path to use (default: \${REPOS_BASE}/<name>)"
 }
 
+# According to PMS 3.1.5.
+check_repository_name() {
+	local rnm="repository name must"
+
+	[[ $1 == -* ]] && die -q "${rnm} not start with hyphen"
+	[[ $1 == +([A-Za-z0-9_-]) ]] ||
+		die -q "${rnm} only contain characters [A-Za-z0-9_-]"
+
+	# Must also be a valid package name. However, a valid package
+	# (vs) name MUST NOT end in a hyphen followed by a version
+	# syntax/specification.
+	local vs_number_part="+([0-9])*(\.+([0-9]))"
+	local vs_suffixes="*(_@(alpha|beta|pre|rc|p)*([0-9]))"
+	local vs_revision="?(-r+([0-9]))"
+	local vs="${vs_number_part}?([a-z])${vs_suffixes}${vs_revision}"
+
+	local neg_vs="*-${vs}"
+	if [[ $1 == ${neg_vs} ]]; then
+		die -q "${rnm} not end with hyphen followed by" \
+			"the version syntax described in PMS section 3.2"
+	fi
+}
+
 do_create() {
 	[[ ${#} -eq 1 || ${#} -eq 2 ]] || die -q "incorrect parameters to create"
 	if [[ ${#} -eq 2 ]]; then
 		[[ ${2} != /* ]] && die -q "path must be absolute"
 	fi
+
+	check_repository_name "${1}"
 
 	get_config
 	update_cache


### PR DESCRIPTION
solves https://bugs.gentoo.org/947628

I wrote the function separately until it worked, then after copying it inside `repository.eselect.in`, I got the diff and reemerged `app-eselect/eselect-repository` with the patch and tested it more